### PR TITLE
Multi scope helpers

### DIFF
--- a/Spotify.NetStandard/Spotify.NetStandard.Test/SpotifyClientApiTest.cs
+++ b/Spotify.NetStandard/Spotify.NetStandard.Test/SpotifyClientApiTest.cs
@@ -622,7 +622,7 @@ namespace Spotify.NetStandard.Test
             var result = await _client.Api.UserPlaybackTransferAsync(
                 new List<string>
                 {
-                    "80f881f68b09341238323926e637e246f96b9159"
+                    "13ec64132fb267dc44d9385a95be0aeeb69dbdd4"
                 },
                 true);
             Assert.IsTrue(result.Success);

--- a/Spotify.NetStandard/Spotify.NetStandard.Test/SpotifyClientAuthTest.cs
+++ b/Spotify.NetStandard/Spotify.NetStandard.Test/SpotifyClientAuthTest.cs
@@ -535,7 +535,7 @@ namespace Spotify.NetStandard.Test
             {
                 DeviceIds = new List<string>
                 {
-                    "80f881f68b09341238323926e637e246f96b9159"
+                    "13ec64132fb267dc44d9385a95be0aeeb69dbdd4"
                 },
                 Play = true
             });

--- a/Spotify.NetStandard/Spotify.NetStandard/Client/Internal/Extensions.cs
+++ b/Spotify.NetStandard/Spotify.NetStandard/Client/Internal/Extensions.cs
@@ -41,7 +41,8 @@ namespace Spotify.NetStandard.Client.Internal
             {
                 foreach (PropertyInfo info in typeof(T).GetProperties())
                 {
-                    if (info.CanRead)
+                    if (info.CanRead && 
+                        info.PropertyType == typeof(bool))
                     {
                         object value = info.GetValue(source, null);
                         if (value != null && (bool)value)

--- a/Spotify.NetStandard/Spotify.NetStandard/Requests/Scope.cs
+++ b/Spotify.NetStandard/Spotify.NetStandard/Requests/Scope.cs
@@ -222,24 +222,64 @@ namespace Spotify.NetStandard.Requests
 
         #region MultiScopeHelpers
 
+        /// <summary>
+        /// Returns a new Scope object with all "read" scopes set to true
+        /// Usage : Scope.ReadAllAccess
+        /// </summary>
         public static Scope ReadAllAccess => new Scope().AddReadAllAccess();
 
+        /// <summary>
+        /// Returns a new Scope object with all "modify" scopes set to true
+        /// Usage : Scope.ModifyAllAccess
+        /// </summary>
         public static Scope ModifyAllAccess => new Scope().AddModifyAllAccess();
 
+        /// <summary>
+        /// Returns a new Scope object with all scopes within the confines of Playlists set to true
+        /// Usage : Scope.PlaylistAll
+        /// </summary>
         public static Scope PlaylistAll => new Scope().AddPlaylistAll();
 
+        /// <summary>
+        /// Returns a new Scope object with all scopes within the confines of Spotify Connect set to true
+        /// Usage : Scope.SpotifyConnectAll
+        /// </summary>
         public static Scope SpotifyConnectAll => new Scope().AddSpotifyConnectAll();
 
+        /// <summary>
+        /// Returns a new Scope object with all scopes within the confines of Listening History set to true
+        /// Usage : Scope.ListeningHistoryAll
+        /// </summary>
         public static Scope ListeningHistoryAll => new Scope().AddListeningHistoryAll();
 
+        /// <summary>
+        /// Returns a new Scope object with all scopes within the confines of Playback set to true
+        /// Usage : Scope.PlaybackAll
+        /// </summary>
         public static Scope PlaybackAll => new Scope().AddPlaybackAll();
 
+        /// <summary>
+        /// Returns a new Scope object with all scopes within the confines of Users set to true
+        /// Usage : Scope.UsersAll
+        /// </summary>
         public static Scope UsersAll => new Scope().AddUsersAll();
 
+        /// <summary>
+        /// Returns a new Scope object with all scopes within the confines of Users set to true
+        /// Usage : Scope.FollowAll
+        /// </summary>
         public static Scope FollowAll => new Scope().AddFollowAll();
 
+        /// <summary>
+        /// Returns a new Scope object with all scopes within the confines of Library set to true
+        /// Usage : Scope.LibraryAll
+        /// </summary>
         public static Scope LibraryAll => new Scope().AddLibraryAll();
 
+        /// <summary>
+        /// Returns a new Scope object with all scopes set to true
+        /// Usage : Scope.AllPermissions
+        /// </summary>
         public static Scope AllPermissions =>
             new Scope()
                 .AddReadAllAccess()

--- a/Spotify.NetStandard/Spotify.NetStandard/Requests/Scope.cs
+++ b/Spotify.NetStandard/Spotify.NetStandard/Requests/Scope.cs
@@ -8,6 +8,7 @@ namespace Spotify.NetStandard.Requests
     public class Scope
     {
         #region Playlists
+
         /// <summary>
         /// Read access to user's private playlists.
         /// <para>Required For</para>
@@ -58,9 +59,11 @@ namespace Spotify.NetStandard.Requests
         /// </summary>
         [Description("playlist-read-collaborative")]
         public bool? PlaylistReadCollaborative { get; set; }
+
         #endregion Playlists
 
         #region Spotify Connect 
+
         /// <summary>
         /// Pause a User's Playback
         /// <para>Required For</para>
@@ -93,9 +96,11 @@ namespace Spotify.NetStandard.Requests
         /// </summary>
         [Description("user-read-playback-state")]
         public bool? ConnectReadPlaybackState { get; set; }
+
         #endregion Spotify Connect 
 
         #region Listening History
+
         /// <summary>
         /// Read access to a user's top artists and tracks. 
         /// <para>Required For</para>
@@ -111,9 +116,11 @@ namespace Spotify.NetStandard.Requests
         /// </summary>
         [Description("user-read-recently-played")]
         public bool? ListeningRecentlyPlayed { get; set; }
+
         #endregion Listening History
 
         #region Playback
+
         /// <summary>
         /// Remote control playback of Spotify.
         /// </summary>
@@ -125,9 +132,11 @@ namespace Spotify.NetStandard.Requests
         /// </summary>
         [Description("streaming")]
         public bool? PlaybackStreaming { get; set; }
+
         #endregion Playback
 
         #region Users
+
         /// <summary>
         /// Read access to the user's birthdate.
         /// <para>Required For</para>
@@ -160,9 +169,11 @@ namespace Spotify.NetStandard.Requests
         /// </summary>
         [Description("ugc-image-upload")]
         public bool? UserGeneratedContentImageUpload { get; set; }
+
         #endregion Users
 
         #region Follow
+
         /// <summary>
         /// Read access to the list of artists and other users that the user follows.
         /// <para>Required For</para>
@@ -180,9 +191,11 @@ namespace Spotify.NetStandard.Requests
         /// </summary>
         [Description("user-follow-modify")]
         public bool? FollowModify { get; set; }
+
         #endregion Follow
 
         #region Library
+
         /// <summary>
         /// Write/delete access to a user's "Your Music" library. 
         /// <para>Required For</para>
@@ -204,6 +217,42 @@ namespace Spotify.NetStandard.Requests
         /// </summary>
         [Description("user-library-read")]
         public bool? LibraryRead { get; set; }
+
         #endregion Library
+
+        #region MultiScopeHelpers
+
+        public static Scope ReadAllAccess => new Scope().AddReadAllAccess();
+
+        public static Scope ModifyAllAccess => new Scope().AddModifyAllAccess();
+
+        public static Scope PlaylistAll => new Scope().AddPlaylistAll();
+
+        public static Scope SpotifyConnectAll => new Scope().AddSpotifyConnectAll();
+
+        public static Scope ListeningHistoryAll => new Scope().AddListeningHistoryAll();
+
+        public static Scope PlaybackAll => new Scope().AddPlaybackAll();
+
+        public static Scope UsersAll => new Scope().AddUsersAll();
+
+        public static Scope FollowAll => new Scope().AddFollowAll();
+
+        public static Scope LibraryAll => new Scope().AddLibraryAll();
+
+        public static Scope AllPermissions =>
+            new Scope()
+                .AddReadAllAccess()
+                .AddModifyAllAccess()
+                .AddPlaylistAll()
+                .AddSpotifyConnectAll()
+                .AddListeningHistoryAll()
+                .AddPlaybackAll()
+                .AddUsersAll()
+                .AddFollowAll()
+                .AddLibraryAll();
+
+        #endregion MultiScopeHelpers
     }
 }
+

--- a/Spotify.NetStandard/Spotify.NetStandard/Requests/ScopeExtensions.cs
+++ b/Spotify.NetStandard/Spotify.NetStandard/Requests/ScopeExtensions.cs
@@ -1,7 +1,15 @@
 ﻿namespace Spotify.NetStandard.Requests
 {
+    /// <summary>
+    /// Extension Methods for Scope Class to allow fluent additions of scopes for the API
+    /// </summary>
     public static class ScopeExtensions
     {
+        /// <summary>
+        /// Extension method to add all scopes with "read" in their scope string
+        /// </summary>
+        /// <param name="scope"></param>
+        /// <returns></returns>
         public static Scope AddReadAllAccess(this Scope scope)
         {
             scope.PlaylistReadCollaborative = true;
@@ -19,6 +27,11 @@
             return scope;
         }
 
+        /// <summary>
+        /// /// Extension method to add all scopes with "modify" in their scope string
+        /// </summary>
+        /// <param name="scope"></param>
+        /// <returns></returns>
         public static Scope AddModifyAllAccess(this Scope scope)
         {
             scope.PlaylistModifyPrivate = true;
@@ -30,6 +43,11 @@
             return scope;
         }
 
+        /// <summary>
+        /// Adds all scopes to a scope within the Playlist section of the defined Scopes
+        /// </summary>
+        /// <param name="scope"></param>
+        /// <returns></returns>
         public static Scope AddPlaylistAll(this Scope scope)
         {
             scope.PlaylistReadPrivate = true;
@@ -40,6 +58,11 @@
             return scope;
         }
 
+        /// <summary>
+        /// /// Adds all scopes to a scope within the Spotify Connect section of the defined Scopes
+        /// </summary>
+        /// <param name="scope"></param>
+        /// <returns></returns>
         public static Scope AddSpotifyConnectAll(this Scope scope)
         {
             scope.ConnectModifyPlaybackState = true;
@@ -49,6 +72,11 @@
             return scope;
         }
 
+        /// <summary>
+        /// /// Adds all scopes to a scope within the Listening History section of the defined Scopes
+        /// </summary>
+        /// <param name="scope"></param>
+        /// <returns></returns>
         public static Scope AddListeningHistoryAll(this Scope scope)
         {
             scope.ListeningTopRead = true;
@@ -57,6 +85,11 @@
             return scope;
         }
 
+        /// <summary>
+        /// /// Adds all scopes to a scope within the Playback section of the defined Scopes
+        /// </summary>
+        /// <param name="scope"></param>
+        /// <returns></returns>
         public static Scope AddPlaybackAll(this Scope scope)
         {
             scope.PlaybackAppRemoteControl = true;
@@ -64,6 +97,11 @@
             return scope;
         }
 
+        /// <summary>
+        /// /// Adds all scopes to a scope within the Users section of the defined Scopes
+        /// </summary>
+        /// <param name="scope"></param>
+        /// <returns></returns>
         public static Scope AddUsersAll(this Scope scope)
         {
             scope.UserReadBirthDate = true;
@@ -74,6 +112,11 @@
             return scope;
         }
 
+        /// <summary>
+        /// /// Adds all scopes to a scope within the Follow section of the defined Scopes
+        /// </summary>
+        /// <param name="scope"></param>
+        /// <returns></returns>
         public static Scope AddFollowAll(this Scope scope)
         {
             scope.FollowRead = true;
@@ -82,6 +125,11 @@
             return scope;
         }
 
+        /// <summary>
+        /// /// Adds all scopes to a scope within the Library section of the defined Scopes
+        /// </summary>
+        /// <param name="scope"></param>
+        /// <returns></returns>
         public static Scope AddLibraryAll(this Scope scope)
         {
             scope.LibraryModify = true;

--- a/Spotify.NetStandard/Spotify.NetStandard/Requests/ScopeExtensions.cs
+++ b/Spotify.NetStandard/Spotify.NetStandard/Requests/ScopeExtensions.cs
@@ -1,0 +1,93 @@
+﻿namespace Spotify.NetStandard.Requests
+{
+    public static class ScopeExtensions
+    {
+        public static Scope AddReadAllAccess(this Scope scope)
+        {
+            scope.PlaylistReadCollaborative = true;
+            scope.PlaylistReadPrivate = true;
+            scope.ConnectReadCurrentlyPlaying = true;
+            scope.ConnectReadPlaybackState = true;
+            scope.ListeningTopRead = true;
+            scope.ListeningRecentlyPlayed = true;
+            scope.UserReadBirthDate = true;
+            scope.UserReadEmail = true;
+            scope.UserReadPrivate = true;
+            scope.FollowRead = true;
+            scope.LibraryRead = true;
+
+            return scope;
+        }
+
+        public static Scope AddModifyAllAccess(this Scope scope)
+        {
+            scope.PlaylistModifyPrivate = true;
+            scope.PlaylistModifyPublic = true;
+            scope.ConnectModifyPlaybackState = true;
+            scope.FollowModify = true;
+            scope.LibraryModify = true;
+
+            return scope;
+        }
+
+        public static Scope AddPlaylistAll(this Scope scope)
+        {
+            scope.PlaylistReadPrivate = true;
+            scope.PlaylistModifyPrivate = true;
+            scope.PlaylistModifyPublic = true;
+            scope.PlaylistReadCollaborative = true;
+
+            return scope;
+        }
+
+        public static Scope AddSpotifyConnectAll(this Scope scope)
+        {
+            scope.ConnectModifyPlaybackState = true;
+            scope.ConnectReadCurrentlyPlaying = true;
+            scope.ConnectReadPlaybackState = true;
+
+            return scope;
+        }
+
+        public static Scope AddListeningHistoryAll(this Scope scope)
+        {
+            scope.ListeningTopRead = true;
+            scope.ListeningRecentlyPlayed = true;
+
+            return scope;
+        }
+
+        public static Scope AddPlaybackAll(this Scope scope)
+        {
+            scope.PlaybackAppRemoteControl = true;
+            scope.PlaybackStreaming = true;
+            return scope;
+        }
+
+        public static Scope AddUsersAll(this Scope scope)
+        {
+            scope.UserReadBirthDate = true;
+            scope.UserReadEmail = true;
+            scope.UserReadPrivate = true;
+            scope.UserGeneratedContentImageUpload = true;
+
+            return scope;
+        }
+
+        public static Scope AddFollowAll(this Scope scope)
+        {
+            scope.FollowRead = true;
+            scope.FollowModify = true;
+
+            return scope;
+        }
+
+        public static Scope AddLibraryAll(this Scope scope)
+        {
+            scope.LibraryModify = true;
+            scope.LibraryRead = true;
+
+            return scope;
+        }
+    }
+}

--- a/Spotify.NetStandard/Spotify.NetStandard/Spotify.NetStandard.csproj
+++ b/Spotify.NetStandard/Spotify.NetStandard/Spotify.NetStandard.csproj
@@ -2,12 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.0.0</Version>
-    <Authors>RoguePlanetoid</Authors>
+    <Version>1.0.1</Version>
+    <Authors>RoguePlanetoid,parkeradam</Authors>
     <Company>Comentsys</Company>
     <Description>Spotify API .NET Standard Library</Description>
     <RepositoryUrl>https://github.com/RoguePlanetoid/Spotify-NetStandard</RepositoryUrl>
-    <PackageReleaseNotes>Beta Release</PackageReleaseNotes>
+    <PackageReleaseNotes>1.0.0 Initial Release
+1.0.1 Added Multi Scope Helpers by parkeradam</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyVersion>0.9.1.0</AssemblyVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Spotify.NetStandard/Spotify.NetStandard/Spotify.NetStandard.xml
+++ b/Spotify.NetStandard/Spotify.NetStandard/Spotify.NetStandard.xml
@@ -4053,6 +4053,134 @@
             Get a User's Saved Tracks</para>
             </summary>
         </member>
+        <member name="P:Spotify.NetStandard.Requests.Scope.ReadAllAccess">
+            <summary>
+            Returns a new Scope object with all "read" scopes set to true
+            Usage : Scope.ReadAllAccess
+            </summary>
+        </member>
+        <member name="P:Spotify.NetStandard.Requests.Scope.ModifyAllAccess">
+            <summary>
+            Returns a new Scope object with all "modify" scopes set to true
+            Usage : Scope.ModifyAllAccess
+            </summary>
+        </member>
+        <member name="P:Spotify.NetStandard.Requests.Scope.PlaylistAll">
+            <summary>
+            Returns a new Scope object with all scopes within the confines of Playlists set to true
+            Usage : Scope.PlaylistAll
+            </summary>
+        </member>
+        <member name="P:Spotify.NetStandard.Requests.Scope.SpotifyConnectAll">
+            <summary>
+            Returns a new Scope object with all scopes within the confines of Spotify Connect set to true
+            Usage : Scope.SpotifyConnectAll
+            </summary>
+        </member>
+        <member name="P:Spotify.NetStandard.Requests.Scope.ListeningHistoryAll">
+            <summary>
+            Returns a new Scope object with all scopes within the confines of Listening History set to true
+            Usage : Scope.ListeningHistoryAll
+            </summary>
+        </member>
+        <member name="P:Spotify.NetStandard.Requests.Scope.PlaybackAll">
+            <summary>
+            Returns a new Scope object with all scopes within the confines of Playback set to true
+            Usage : Scope.PlaybackAll
+            </summary>
+        </member>
+        <member name="P:Spotify.NetStandard.Requests.Scope.UsersAll">
+            <summary>
+            Returns a new Scope object with all scopes within the confines of Users set to true
+            Usage : Scope.UsersAll
+            </summary>
+        </member>
+        <member name="P:Spotify.NetStandard.Requests.Scope.FollowAll">
+            <summary>
+            Returns a new Scope object with all scopes within the confines of Users set to true
+            Usage : Scope.FollowAll
+            </summary>
+        </member>
+        <member name="P:Spotify.NetStandard.Requests.Scope.LibraryAll">
+            <summary>
+            Returns a new Scope object with all scopes within the confines of Library set to true
+            Usage : Scope.LibraryAll
+            </summary>
+        </member>
+        <member name="P:Spotify.NetStandard.Requests.Scope.AllPermissions">
+            <summary>
+            Returns a new Scope object with all scopes set to true
+            Usage : Scope.AllPermissions
+            </summary>
+        </member>
+        <member name="T:Spotify.NetStandard.Requests.ScopeExtensions">
+            <summary>
+            Extension Methods for Scope Class to allow fluent additions of scopes for the API
+            </summary>
+        </member>
+        <member name="M:Spotify.NetStandard.Requests.ScopeExtensions.AddReadAllAccess(Spotify.NetStandard.Requests.Scope)">
+            <summary>
+            Extension method to add all scopes with "read" in their scope string
+            </summary>
+            <param name="scope"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Spotify.NetStandard.Requests.ScopeExtensions.AddModifyAllAccess(Spotify.NetStandard.Requests.Scope)">
+            <summary>
+            /// Extension method to add all scopes with "modify" in their scope string
+            </summary>
+            <param name="scope"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Spotify.NetStandard.Requests.ScopeExtensions.AddPlaylistAll(Spotify.NetStandard.Requests.Scope)">
+            <summary>
+            Adds all scopes to a scope within the Playlist section of the defined Scopes
+            </summary>
+            <param name="scope"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Spotify.NetStandard.Requests.ScopeExtensions.AddSpotifyConnectAll(Spotify.NetStandard.Requests.Scope)">
+            <summary>
+            /// Adds all scopes to a scope within the Spotify Connect section of the defined Scopes
+            </summary>
+            <param name="scope"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Spotify.NetStandard.Requests.ScopeExtensions.AddListeningHistoryAll(Spotify.NetStandard.Requests.Scope)">
+            <summary>
+            /// Adds all scopes to a scope within the Listening History section of the defined Scopes
+            </summary>
+            <param name="scope"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Spotify.NetStandard.Requests.ScopeExtensions.AddPlaybackAll(Spotify.NetStandard.Requests.Scope)">
+            <summary>
+            /// Adds all scopes to a scope within the Playback section of the defined Scopes
+            </summary>
+            <param name="scope"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Spotify.NetStandard.Requests.ScopeExtensions.AddUsersAll(Spotify.NetStandard.Requests.Scope)">
+            <summary>
+            /// Adds all scopes to a scope within the Users section of the defined Scopes
+            </summary>
+            <param name="scope"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Spotify.NetStandard.Requests.ScopeExtensions.AddFollowAll(Spotify.NetStandard.Requests.Scope)">
+            <summary>
+            /// Adds all scopes to a scope within the Follow section of the defined Scopes
+            </summary>
+            <param name="scope"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Spotify.NetStandard.Requests.ScopeExtensions.AddLibraryAll(Spotify.NetStandard.Requests.Scope)">
+            <summary>
+            /// Adds all scopes to a scope within the Library section of the defined Scopes
+            </summary>
+            <param name="scope"></param>
+            <returns></returns>
+        </member>
         <member name="T:Spotify.NetStandard.Requests.SearchType">
             <summary>
             Search Type


### PR DESCRIPTION
Added helpers to easily enable developers to quickly get scope objects with the related scopes checked. 
Addes extension methods to Scope object to allow developers to fluently build up a scope object and add multiple scope areas in quick succession. 